### PR TITLE
Fix dockerfile installing wrong .NET SDK version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN rm packages-microsoft-prod.deb
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     apt-transport-https \
-    dotnet-sdk-6.0
+    dotnet-sdk-8.0
 
 ###
 ### Generator image


### PR DESCRIPTION
I'm not sure _how_ this happened precisely but this was not bumped in #2 while it should have been. Caused `docker build` to fail.