### PR TITLE
Add verify scores step

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,12 @@ services:
     working_dir: '/app/setup'
     command: [ './import.sh' ]
 
+  # Verify scores
+  verify:
+    <<: *x-common
+    working_dir: '/app/verify'
+    command: [ './start.sh' ]
+
   # Difficulty calculation
   diffcalc:
     <<: *x-common
@@ -82,6 +88,8 @@ services:
       <<: *x-common-depends
       # To support running `docker-compose up generator`...
       setup:
+        condition: service_started
+      verify:
         condition: service_started
       diffcalc:
         condition: service_started

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -35,9 +35,10 @@ RED='\033[0;31m'
 
 STEP_IMPORT=-1
 STEP_DIFFCALC=0
-STEP_PPCALC_SCORE=1
-STEP_PPCALC_USER=2
-STEP_GENERATE=3
+STEP_VERIFY=1
+STEP_PPCALC_SCORE=2
+STEP_PPCALC_USER=3
+STEP_GENERATE=4
 
 ### Clones a given repository URL into a target directory.
 ### The URL may link to a pull request, commit, or tree.

--- a/docker/verify/start.sh
+++ b/docker/verify/start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+source ../common.sh
+
+### Runs the score statistics processor to verify imported scores.
+###
+### Usage: verify_scores <db_name> <processor_dir>
+function verify_scores() {
+    local db_name=$1
+    local processor_dir=$2
+
+    wait_for_step "${db_name}" "${STEP_VERIFY}" \
+        || { echo "Scores have already been verified."; return; }
+
+    cd $processor_dir
+    ./UseLocalOsu.sh
+
+    DB_NAME=$db_name \
+    dotnet run \
+        -c:Release \
+        --project osu.Server.Queues.ScoreStatisticsProcessor \
+        -- \
+        maintenance \
+        verify-imported-scores \
+        --ruleset-id ${RULESET_ID}
+
+    next_step "${db_name}"
+}
+
+PROCESSOR_A_DIR="${WORKDIR_A}/osu-queue-score-statistics"
+PROCESSOR_B_DIR="${WORKDIR_B}/osu-queue-score-statistics"
+
+echo "[PROCESSOR_A] => ${PROCESSOR_A_DIR}"
+echo "[PROCESSOR_B] => ${PROCESSOR_B_DIR}"
+
+clone_repo "${SCORE_PROCESSOR_A}" "${PROCESSOR_A_DIR}"
+clone_repo "${SCORE_PROCESSOR_B}" "${PROCESSOR_B_DIR}"
+
+verify_scores "${OSU_A_HASH}" "${PROCESSOR_A_DIR}"
+verify_scores "${OSU_B_HASH}" "${PROCESSOR_B_DIR}"


### PR DESCRIPTION
Should fix https://github.com/smoogipoo/diffcalc-sheet-generator/issues/9

Adds a step that runs the [`verify-imported-highscores`](https://github.com/ppy/osu-queue-score-statistics/blob/a1781aade4abadc279bade23b06ed85ec2558ed6/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs) command.