### PR TITLE
Remove deprecated 'version' property

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 x-build-context: &x-build-context
   context: ./docker
   dockerfile: Dockerfile


### PR DESCRIPTION
See https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete