### PR TITLE
Set `DB_USERS_TABLE` variable

### DIFF
--- a/docker/common.sh
+++ b/docker/common.sh
@@ -7,10 +7,12 @@ set -u
 : ${DB_PORT:=3306}
 : ${DB_USER:="root"}
 : ${MAX_DATABASE_SIZE:=0}
+: ${DB_USERS_TABLE:="sample_users"}
 
 export DB_HOST
 export DB_PORT
 export DB_USER
+export DB_USERS_TABLE
 
 
 MYSQL_ARGS=(


### PR DESCRIPTION
I haven't tested, but I think this should fix the following:
```
2025-03-17T13:23:49.4625861Z ppcalc-1     | Fetching all users...
2025-03-17T13:23:49.9216578Z ppcalc-1     | Unhandled exception. MySqlConnector.MySqlException (0x80004005): Table '87b6dddd11f3018ca34342098abdd13e6d39c1c5.phpbb_users' doesn't exist
2025-03-17T13:23:49.9219465Z ppcalc-1     |    at MySqlConnector.Core.ServerSession.ReceiveReplyAsync(IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/Core/ServerSession.cs:line 885
2025-03-17T13:23:49.9221605Z ppcalc-1     |    at MySqlConnector.Core.ResultSet.ReadResultSetHeaderAsync(IOBehavior ioBehavior) in /_/src/MySqlConnector/Core/ResultSet.cs:line 37
2025-03-17T13:23:49.9224073Z ppcalc-1     |    at MySqlConnector.MySqlDataReader.ActivateResultSet(CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlDataReader.cs:line 130
2025-03-17T13:23:49.9229592Z ppcalc-1     |    at MySqlConnector.MySqlDataReader.InitAsync(CommandListPosition commandListPosition, ICommandPayloadCreator payloadCreator, IDictionary`2 cachedProcedures, IMySqlCommand command, CommandBehavior behavior, Activity activity, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlDataReader.cs:line 482
2025-03-17T13:23:49.9232475Z ppcalc-1     |    at MySqlConnector.Core.CommandExecutor.ExecuteReaderAsync(CommandListPosition commandListPosition, ICommandPayloadCreator payloadCreator, CommandBehavior behavior, Activity activity, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/Core/CommandExecutor.cs:line 56
2025-03-17T13:23:49.9234567Z ppcalc-1     |    at MySqlConnector.MySqlCommand.ExecuteReaderAsync(CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlCommand.cs:line 357
2025-03-17T13:23:49.9236103Z ppcalc-1     |    at MySqlConnector.MySqlCommand.ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlCommand.cs:line 350
2025-03-17T13:23:49.9237422Z ppcalc-1     |    at Dapper.SqlMapper.QueryAsync[T](IDbConnection cnn, Type effectiveType, CommandDefinition command) in /_/Dapper/SqlMapper.Async.cs:line 434
2025-03-17T13:23:49.9239578Z ppcalc-1     |    at osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.UserTotals.UpdateAllUserTotalsCommand.ExecuteAsync(CancellationToken cancellationToken) in /tmp/tmp.c2krJC4Yy4/osu-queue-score-statistics/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateAllUserTotalsCommand.cs:line 30
2025-03-17T13:23:49.9242425Z ppcalc-1     |    at osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.PerformanceCommand.OnExecuteAsync(CancellationToken cancellationToken) in /tmp/tmp.c2krJC4Yy4/osu-queue-score-statistics/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs:line 41
```

See:
https://github.com/ppy/osu-queue-score-statistics/blob/7ffbd77361a9446f406618a33b200c1c4f0f4af8/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyDatabaseHelper.cs#L62

Now used when processing user pp totals:
https://github.com/ppy/osu-queue-score-statistics/blob/7ffbd77361a9446f406618a33b200c1c4f0f4af8/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateAllUserTotalsCommand.cs#L28-L34