### PR TITLE
Add Aspire maps filtering

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,6 +24,12 @@ RULESET=osu
 NO_CONVERTS=0
 
 #
+# Whether to output SR/PP for Aspire-like maps.
+#
+# Supported values: [ 0, 1 ]
+NO_ASPIRE=1
+
+#
 # Whether to output SR/PP only for ranked beatmaps.
 #
 # Supported values: [ 0, 1 ]

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -224,6 +224,7 @@ export RULESET_ID
 export OSU_A_HASH
 export OSU_B_HASH
 export NO_CONVERTS
+export NO_ASPIRE
 export RANKED_ONLY
 export GENERATORS
 export THREADS

--- a/docker/generator/Env.cs
+++ b/docker/generator/Env.cs
@@ -10,6 +10,7 @@ public static class Env
     public static readonly string DB_A;
     public static readonly string DB_B;
     public static readonly bool NO_CONVERTS;
+    public static readonly bool NO_ASPIRE;
     public static readonly bool RANKED_ONLY;
     public static readonly double TOLERANCE;
     public static readonly string[] GENERATOR_LIST;
@@ -24,6 +25,7 @@ public static class Env
         DB_A = Environment.GetEnvironmentVariable("OSU_A_HASH") ?? throw new InvalidOperationException("Missing OSU_A_HASH environment variable.");
         DB_B = Environment.GetEnvironmentVariable("OSU_B_HASH") ?? throw new InvalidOperationException("Missing OSU_B_HASH environment variable.");
         NO_CONVERTS = Environment.GetEnvironmentVariable("NO_CONVERTS") == "1";
+        NO_ASPIRE = Environment.GetEnvironmentVariable("NO_ASPIRE") == "1";
         RANKED_ONLY = Environment.GetEnvironmentVariable("RANKED_ONLY") == "1";
         TOLERANCE = double.TryParse(Environment.GetEnvironmentVariable("TOLERANCE"), out double tolerance) ? tolerance : 0.1;
 

--- a/docker/generator/Generators/IGenerator.cs
+++ b/docker/generator/Generators/IGenerator.cs
@@ -24,6 +24,8 @@ namespace Generator.Generators
 
             if (Env.NO_CONVERTS)
                 add(builder, $"`{selector}`.`playmode` = @RulesetId");
+            if (Env.NO_ASPIRE)
+                add(builder, $"`{selector}`.`id` NOT IN {GetAspireBlacklistDatabaseArray()}");
             if (Env.RANKED_ONLY)
                 add(builder, $"`{selector}`.`approved` IN (1, 2)");
 
@@ -35,6 +37,40 @@ namespace Generator.Generators
                     builder.Append(" AND ");
                 builder.Append(query);
             }
+        }
+
+        private static string GetAspireBlacklistDatabaseArray()
+        {
+            // technically there are some non-aspire maps here but the idea is still the same
+            int[] aspireMapBlacklist =
+            [
+                1258033, // (MinG3012) The Solace of Oblivion
+                1257904, // (ProfessionalBox) The Solace of Oblivion
+                1529760, // (Rucker) Der Wald [NiNo's Aspire]
+                1529757, // (Rucker) Der Wald [Hey jia]
+                1408449, // (fanzhen0019) GHOST
+                2055234, // (DTM9 Nowa) Acid Rain
+                2087153, // (seselis1) Acid Rain
+                2571609, // (Meow Mix) Space Invaders
+                2571016, // (ScubDomino) cherry blossoms explode across the dying horizon [wabi � sabi]
+                2573886, // (ScubDomino) cherry blossoms explode across the dying horizon [�debug]
+                2571139, // (ShotgunApe) THE SKIES OPEN [SHADOW OF TOMORROW]
+                2572147, // (ShotgunApe) THE SKIES OPEN [Debug]
+                2571858, // (mantasu) Unshakable
+                2628991, // (fanzhen0019) XNOR XNOR XNOR [Moon]
+                2573161, // (fanzhen0019) XNOR XNOR XNOR [Earth (atm)]
+                2619200, // (fanzhen0019) XNOR XNOR XNOR [Earth]
+                2571051, // (fanzhen0019) XNOR XNOR XNOR [.-- .-. --- -. --. .-- .- -.--]
+                2573164, // (fanzhen0019) XNOR XNOR XNOR [Beloved Exclusive]
+                1029976, // (MinG3012) Grenade
+                2536330, // (Acylica) Flashbacklog
+                1314546, // (rustbell) HYENA [:thinking:]
+                1314545, // (rustbell) HYENA [caonimenquanbu]
+                4553451, // (pw384) Nhelv [Distortion fix (no autofail debug)]
+                4679228 // (pw384) Nhelv [KATASTROPHE]
+            ];
+
+            return $"({string.Join(',', aspireMapBlacklist)})";
         }
     }
 

--- a/docker/generator/Program.cs
+++ b/docker/generator/Program.cs
@@ -11,6 +11,7 @@ titleBuilder.Append($"{Env.RULESET}: ");
 titleBuilder.Append($"{Env.DB_A[..7]} (A) vs {Env.DB_B[..7]} (B) ");
 titleBuilder.Append("| ");
 titleBuilder.Append($"converts: {!Env.NO_CONVERTS}, ");
+titleBuilder.Append($"aspire: {!Env.NO_ASPIRE}, ");
 titleBuilder.Append($"ranked-only: {Env.RANKED_ONLY}");
 if (Env.MOD_FILTERS.Length != 0)
     titleBuilder.Append($", mods: {Env.MOD_FILTERS_RAW}");


### PR DESCRIPTION
Aspire maps pollute sheets very hard with pretty much useless deltas, so this is meant to be able to ignore them. Not all maps in the list are technically aspire maps, some are spiritually aspire and there's one dodge-the-beat map